### PR TITLE
Fix documentation issues

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: survdistr
 Title: Survival Distribution Container with Flexible Interpolation Methods
-Version: 0.0.2.9000
+Version: 0.0.3
 Authors@R: c(
     person("John", "Zobolas", , "bblodfon@gmail.com", role = c("aut", "cre")),
     person("Andreas", "Bender", , "andreas.bender@stat.uni-muenchen.de", role = "ctb")

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 - Introduced `trim_duplicates()` to remove repeated S(t) values across the time axis, with tolerance.
 - Added `interp_cif()` for constant interpolation of CIF (uses C++ internally).
 - Added `extract_times()` to consistently obtain and validate time points from vectors or matrices.
-- Unified assertion function to one: `assert_prob()`.
+- Unified assertion functions into one: `assert_prob()`.
 - Unified `mat_interp()` and `vec_interp()` into a single `interp()` function.
 - Enhanced `interp()`:
   - Added aliases for the three interpolation options (e.g., `const_haz` is equivalent to `exp_surv`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# survdistr (development version)
+# survdistr 0.0.3
+
+- Improved documentation
+- Refactored `interp_cif()`
+- Added trapezoidal integration option for continuous hazard/density to survival conversion in `convert_to_surv()`
+- Renamed argument: `trim_duplicates` to `trim_dups`
 
 # survdistr 0.0.2
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -33,11 +33,11 @@ c_disc_haz_to_surv_mat <- function(x) {
     .Call(`_survdistr_c_disc_haz_to_surv_mat`, x)
 }
 
-c_cont_dens_to_surv_mat <- function(x, times) {
-    .Call(`_survdistr_c_cont_dens_to_surv_mat`, x, times)
+c_cont_dens_to_surv_mat <- function(x, times, trapezoid = TRUE) {
+    .Call(`_survdistr_c_cont_dens_to_surv_mat`, x, times, trapezoid)
 }
 
-c_cont_haz_to_surv_mat <- function(x, times) {
-    .Call(`_survdistr_c_cont_haz_to_surv_mat`, x, times)
+c_cont_haz_to_surv_mat <- function(x, times, trapezoid = TRUE) {
+    .Call(`_survdistr_c_cont_haz_to_surv_mat`, x, times, trapezoid)
 }
 

--- a/R/as_survDistr.R
+++ b/R/as_survDistr.R
@@ -20,12 +20,12 @@ as_survDistr = function(x, ...) {
 #'   Interpolation method passed to [survDistr] constructor.
 #' @param check (`logical(1)`)\cr
 #'   Whether to validate `x` and `times`.
-#' @param trim_duplicates (`logical(1)`)\cr
+#' @param trim_dups (`logical(1)`)\cr
 #'  Whether to remove duplicate S(t) values and corresponding time points.
 #' @export
 as_survDistr.matrix = function(x, times = NULL, method = "const_surv", check = TRUE,
-                               trim_duplicates = FALSE, ...) {
-  survDistr$new(x = x, times = times, method = method, check = check, trim_duplicates = trim_duplicates)
+                               trim_dups = FALSE, ...) {
+  survDistr$new(x = x, times = times, method = method, check = check, trim_dups = trim_dups)
 }
 
 #' @rdname as_survDistr

--- a/R/convert_to_surv.R
+++ b/R/convert_to_surv.R
@@ -17,10 +17,26 @@
 #' \deqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
 #'
 #' * Continuous densities \eqn{f_k} (`"cont_dens"`):
-#' \deqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
+#'   - Trapezoidal rule:
+#'     \deqn{S_j = 1 - \sum_{k=1}^j \frac{f_{k-1} + f_k}{2} \Delta_k}
+#'     (with \eqn{f_0 = f_1})
+#'   - Left Riemann sum:
+#'     \deqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
 #'
 #' * Continuous hazards \eqn{\lambda_k} (`"cont_haz"`):
-#' \deqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
+#'   - Trapezoidal rule:
+#'     \deqn{S_j = \exp\!\left(-\sum_{k=1}^j \frac{\lambda_{k-1} + \lambda_k}{2} \Delta_k\right)}
+#'     (with \eqn{\lambda_0 = \lambda_1})
+#'   - Left Riemann sum:
+#'     \deqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
+#'
+#' For continuous inputs (`"cont_dens"` / `"cont_haz"`), numerical integration
+#' can be done either with the trapezoidal rule (`integration = "trapezoid"`, default)
+#' or with a left Riemann sum (`integration = "riemann"`).
+#' Trapezoidal rule is more accurate (lower approximation error in the order of \eqn{\Delta^2}
+#' while the Riemann sum has an approximation error in the order of \eqn{\Delta}).
+#' At the first anchor both rules are identical, because no previous anchor value
+#' is available; therefore both use \eqn{x_1 \Delta_1}.
 #'
 #' @section Validation:
 #' If `check = TRUE`, we validate that the input is a proper discrete density/hazard matrix
@@ -37,6 +53,10 @@
 #' @param check (`logical(1)`)\cr
 #'  If `TRUE` (default), run \emph{input} validation checks.
 #'  Disable only if you know the input is valid and want to skip checks for speed.
+#' @param integration (`character(1)`)\cr
+#'  Numerical integration rule for continuous inputs:
+#'  `"trapezoid"` (default) uses the trapezoidal rule, while `"riemann"`
+#'  is the left Riemann sum. Only used for `"cont_dens"` and `"cont_haz"`.
 #' @param clamp_surv (`logical(1)`)\cr
 #'  If `TRUE`, clamp survival probabilities to `[eps, 1]` to avoid numerical issues.
 #' @param eps (`numeric(1)`)\cr
@@ -57,10 +77,11 @@
 #'
 #' @export
 convert_to_surv = function(x, times = NULL, input = "cont_haz", check = TRUE,
-                           clamp_surv = FALSE, eps = 1e-12) {
+                           integration = "trapezoid", clamp_surv = FALSE, eps = 1e-12) {
   check = assert_flag(check)
   clamp_surv = assert_flag(clamp_surv)
   input = assert_choice(input, c("disc_dens", "disc_haz", "cont_dens", "cont_haz"))
+  integration = assert_choice(integration, c("trapezoid", "riemann"))
   times = extract_times(x, times)
   is_mat = is.matrix(x)
   x_mat = if (is_mat) x else matrix(x, nrow = 1)
@@ -79,8 +100,8 @@ convert_to_surv = function(x, times = NULL, input = "cont_haz", check = TRUE,
   surv = switch(input,
     "disc_dens" = c_disc_dens_to_surv_mat(x_mat),
     "disc_haz"  = c_disc_haz_to_surv_mat(x_mat),
-    "cont_dens" = c_cont_dens_to_surv_mat(x_mat, times),
-    "cont_haz"  = c_cont_haz_to_surv_mat(x_mat, times)
+    "cont_dens" = c_cont_dens_to_surv_mat(x_mat, times, integration == "trapezoid"),
+    "cont_haz"  = c_cont_haz_to_surv_mat(x_mat, times, integration == "trapezoid")
   )
 
   if (clamp_surv) {

--- a/R/convert_to_surv.R
+++ b/R/convert_to_surv.R
@@ -8,15 +8,19 @@
 #' Let \eqn{t_1,\dots,t_B} denote the anchor time points,
 #' \eqn{\Delta_j = t_j - t_{j-1}}, and \eqn{S_j = S(t_j)} the survival
 #' probabilities at the anchors. The conversion depends on the value
-#' of `input`:
+#' of **input** as follows:
 #'
-#' * `"disc_dens"`: \eqn{S_j = 1 - \sum_{k=1}^j \tilde f_k}
+#' * Discrete densities \eqn{\tilde f_k} (`"disc_dens"`):
+#'  \deqn{S_j = 1 - \sum_{k=1}^j \tilde f_k}
 #'
-#' * `"disc_haz"`: \eqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
+#' * Discrete hazards \eqn{\tilde h_k} (`"disc_haz"`):
+#' \deqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
 #'
-#' * `"cont_dens"`: \eqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
+#' * Continuous densities \eqn{f_k} (`"cont_dens"`):
+#' \deqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
 #'
-#' * `"cont_haz"`: \eqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
+#' * Continuous hazards \eqn{\lambda_k} (`"cont_haz"`):
+#' \deqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
 #'
 #' @section Validation:
 #' If `check = TRUE`, we validate that the input is a proper discrete density/hazard matrix

--- a/R/interp.R
+++ b/R/interp.R
@@ -15,7 +15,8 @@
 #' - `"const_haz"`/`"exp_surv"`: exponential interpolation of S(t) (equivalent to
 #' piecewise constant interpolation of the hazard function).
 #'
-#' For formulas for each method, see respective Tables in arxiv preprint (TODO: add link).
+#' We will provide tables with the interpolation formulas for each method in an
+#' upcoming arXiv preprint and link it here.
 #'
 #' For constant hazard interpolation (`"const_haz"`), any right-anchor S(t) values
 #' equal to 0 are internally floored at `min(1e-12, S_left)` within each interval.
@@ -126,8 +127,9 @@ interp = function(x,
   process_output(res, eval_times, output, add_times, eps)
 }
 
-#' Interpolate CIF matrix
+#' @title Interpolate CIF matrix
 #'
+#' @description
 #' Interpolates cumulative incidence (CIF) functions (corresponding to one
 #' competing event only) using left-continuous constant interpolation.
 #'

--- a/R/interp.R
+++ b/R/interp.R
@@ -35,7 +35,7 @@
 #' @template param_eval_times
 #' @template param_check
 #' @template param_eps
-#' @template param_trim_duplicates
+#' @template param_trim_dups
 #'
 #' @return A numeric vector or matrix of interpolated values.
 #'
@@ -75,13 +75,13 @@ interp = function(x,
                   add_times = TRUE,
                   check = TRUE,
                   eps = 1e-12,
-                  trim_duplicates = FALSE) {
+                  trim_dups = FALSE) {
   # quick assertions
   method = map_interp_method(method) # const_* aliases
   output = assert_choice(output, c("surv", "cdf", "cumhaz", "density", "hazard"))
   assert_flag(add_times)
   assert_flag(check)
-  assert_flag(trim_duplicates)
+  assert_flag(trim_dups)
   eval_times = assert_numeric(
     eval_times, lower = 0, unique = TRUE, sorted = TRUE,
     null.ok = TRUE, any.missing = FALSE, min.len = 1
@@ -89,7 +89,7 @@ interp = function(x,
   is_mat = is.matrix(x)
 
   # remove flat S(t) segments
-  if (trim_duplicates) {
+  if (trim_dups) {
     trimmed = trim_duplicates(x, times = times)
     x = trimmed$x
     times = trimmed$times

--- a/R/interp.R
+++ b/R/interp.R
@@ -160,18 +160,16 @@ interp_cif = function(x, times = NULL, eval_times = NULL, add_times = TRUE, chec
     times = extract_times(x, times)
   }
 
-  # Case: no interpolation requested
+  # Case: no interpolation requested => use anchor times
   if (is.null(eval_times)) {
-    if (add_times) {
-      if (is.null(colnames(x))) {
-        colnames(x) = as.character(times)
-      }
-    }
-    return(x)
+    eval_times = times
   }
 
-  # call C++ interpolation
-  res = c_interp_cif_mat(x, times, eval_times)
+  res = if (identical(eval_times, times)) {
+    x # we have CIF(t) at the anchors already
+  } else {
+    c_interp_cif_mat(x, times, eval_times)
+  }
 
   if (add_times) {
     colnames(res) = as.character(eval_times)

--- a/R/survDistr.R
+++ b/R/survDistr.R
@@ -75,7 +75,7 @@ survDistr = R6Class(
     #' @param x (`matrix`)\cr
     #'  A numeric matrix of survival probabilities (values between 0 and 1).
     #'  Column names must correspond to time points if `times` is `NULL`.
-    #' @param times (`numeric(1)`)\cr Numeric vector of time points for matrix `x`,
+    #' @param times (`numeric()`)\cr Numeric vector of time points for matrix `x`,
     #'  must match the number of columns.
     #' @template param_method
     #' @template param_check

--- a/R/survDistr.R
+++ b/R/survDistr.R
@@ -27,7 +27,7 @@
 #' `check` is set to `TRUE`.
 #' - Use the `$filter()` method to subset observations in-place by filtering rows of the
 #' stored matrix.
-#' - Use `trim_duplicates = TRUE` in the constructor to remove flat survival segments (repeated
+#' - Use `trim_dups = TRUE` in the constructor to remove flat survival segments (repeated
 #' values across time points) with a pre-specified tolerance (for a more controlled
 #' pre-processing, see [trim_duplicates()]).
 #'
@@ -79,16 +79,16 @@ survDistr = R6Class(
     #'  must match the number of columns.
     #' @template param_method
     #' @template param_check
-    #' @template param_trim_duplicates
+    #' @template param_trim_dups
     initialize = function(x, times = NULL, method = "const_surv", check = TRUE,
-                          trim_duplicates = FALSE) {
+                          trim_dups = FALSE) {
       assert_flag(check)
-      assert_flag(trim_duplicates)
+      assert_flag(trim_dups)
       method = map_interp_method(method) # const_* aliases
       private$.method = method
 
       # remove flat S(t) segments
-      if (trim_duplicates) {
+      if (trim_dups) {
         trimmed = trim_duplicates(x, times = times)
         x = trimmed$x
         times = trimmed$times

--- a/README.Rmd
+++ b/README.Rmd
@@ -7,7 +7,7 @@ output: github_document
 Survival distribution container for efficient storage, management, and interpolation of survival model predictions.
 
 <!-- badges: start -->
-[![r-cmd-check](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/mlr3survival/actions/workflows/r-cmd-check.yml)
+[![r-cmd-check](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml)
 [![Codecov test coverage](https://codecov.io/gh/mlr-org/survdistr/branch/main/graph/badge.svg)](https://app.codecov.io/gh/mlr-org/survdistr?branch=main)
 [![CRAN Status](https://www.r-pkg.org/badges/version-ago/survdistr)](https://cran.r-project.org/package=survdistr)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ interpolation of survival model predictions.
 
 <!-- badges: start -->
 
-[![r-cmd-check](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/mlr3survival/actions/workflows/r-cmd-check.yml)
+[![r-cmd-check](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml/badge.svg)](https://github.com/mlr-org/survdistr/actions/workflows/r-cmd-check.yml)
 [![Codecov test
 coverage](https://codecov.io/gh/mlr-org/survdistr/branch/main/graph/badge.svg)](https://app.codecov.io/gh/mlr-org/survdistr?branch=main)
 [![CRAN

--- a/man-roxygen/param_method.R
+++ b/man-roxygen/param_method.R
@@ -1,4 +1,3 @@
 #' @param method (`character(1)`)\cr
-#'  Interpolation method; one of `"const_surv"` (default), `"const_dens"` (alias: `"linear_surv"`) 
+#'  Interpolation method; one of `"const_surv"` (default), `"const_dens"` (alias: `"linear_surv"`)
 #'  and `"const_haz"` (alias: `"exp_surv"`).
-#'  

--- a/man-roxygen/param_rows.R
+++ b/man-roxygen/param_rows.R
@@ -1,5 +1,5 @@
-    #' @param rows (`integer()` | `logical()` | `NULL`)\cr
-    #'  Row indices or a logical vector used to filter observations.
-    #'  Logical vectors must have length equal to the number of observations.
-    #'  Integer indices must be positive and within range.
-    #'  If `NULL`, no filtering is applied.
+#' @param rows (`integer()` | `logical()` | `NULL`)\cr
+#'  Row indices or a logical vector used to filter observations.
+#'  Logical vectors must have length equal to the number of observations.
+#'  Integer indices must be positive and within range.
+#'  If `NULL`, no filtering is applied.

--- a/man-roxygen/param_trim_dups.R
+++ b/man-roxygen/param_trim_dups.R
@@ -1,4 +1,4 @@
-#' @param trim_duplicates (`logical(1)`)\cr
+#' @param trim_dups (`logical(1)`)\cr
 #'  If `TRUE`, removes adjacent duplicate values from the input using [trim_duplicates()].
 #'  This eliminates flat segments in survival curves and improves interpolation efficiency.
 #'  Default is `FALSE`.

--- a/man/as_survDistr.Rd
+++ b/man/as_survDistr.Rd
@@ -14,7 +14,7 @@ as_survDistr(x, ...)
   times = NULL,
   method = "const_surv",
   check = TRUE,
-  trim_duplicates = FALSE,
+  trim_dups = FALSE,
   ...
 )
 
@@ -37,7 +37,7 @@ Interpolation method passed to \link{survDistr} constructor.}
 \item{check}{(\code{logical(1)})\cr
 Whether to validate \code{x} and \code{times}.}
 
-\item{trim_duplicates}{(\code{logical(1)})\cr
+\item{trim_dups}{(\code{logical(1)})\cr
 Whether to remove duplicate S(t) values and corresponding time points.}
 }
 \value{

--- a/man/convert_to_surv.Rd
+++ b/man/convert_to_surv.Rd
@@ -45,12 +45,16 @@ probabilities at the same anchor time points (no interpolation).
 Let \eqn{t_1,\dots,t_B} denote the anchor time points,
 \eqn{\Delta_j = t_j - t_{j-1}}, and \eqn{S_j = S(t_j)} the survival
 probabilities at the anchors. The conversion depends on the value
-of \code{input}:
+of \strong{input} as follows:
 \itemize{
-\item \code{"disc_dens"}: \eqn{S_j = 1 - \sum_{k=1}^j \tilde f_k}
-\item \code{"disc_haz"}: \eqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
-\item \code{"cont_dens"}: \eqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
-\item \code{"cont_haz"}: \eqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
+\item Discrete densities \eqn{\tilde f_k} (\code{"disc_dens"}):
+\deqn{S_j = 1 - \sum_{k=1}^j \tilde f_k}
+\item Discrete hazards \eqn{\tilde h_k} (\code{"disc_haz"}):
+\deqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
+\item Continuous densities \eqn{f_k} (\code{"cont_dens"}):
+\deqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
+\item Continuous hazards \eqn{\lambda_k} (\code{"cont_haz"}):
+\deqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
 }
 }
 \section{Validation}{

--- a/man/convert_to_surv.Rd
+++ b/man/convert_to_surv.Rd
@@ -9,6 +9,7 @@ convert_to_surv(
   times = NULL,
   input = "cont_haz",
   check = TRUE,
+  integration = "trapezoid",
   clamp_surv = FALSE,
   eps = 1e-12
 )
@@ -26,6 +27,11 @@ Input type. One of \code{"disc_haz"}, \code{"disc_dens"}, \code{"cont_haz"} or \
 \item{check}{(\code{logical(1)})\cr
 If \code{TRUE} (default), run \emph{input} validation checks.
 Disable only if you know the input is valid and want to skip checks for speed.}
+
+\item{integration}{(\code{character(1)})\cr
+Numerical integration rule for continuous inputs:
+\code{"trapezoid"} (default) uses the trapezoidal rule, while \code{"riemann"}
+is the left Riemann sum. Only used for \code{"cont_dens"} and \code{"cont_haz"}.}
 
 \item{clamp_surv}{(\code{logical(1)})\cr
 If \code{TRUE}, clamp survival probabilities to \verb{[eps, 1]} to avoid numerical issues.}
@@ -52,10 +58,30 @@ of \strong{input} as follows:
 \item Discrete hazards \eqn{\tilde h_k} (\code{"disc_haz"}):
 \deqn{S_j = \prod_{k=1}^j (1 - \tilde h_k)}
 \item Continuous densities \eqn{f_k} (\code{"cont_dens"}):
+\itemize{
+\item Trapezoidal rule:
+\deqn{S_j = 1 - \sum_{k=1}^j \frac{f_{k-1} + f_k}{2} \Delta_k}
+(with \eqn{f_0 = f_1})
+\item Left Riemann sum:
 \deqn{S_j = 1 - \sum_{k=1}^j f_k \Delta_k}
+}
 \item Continuous hazards \eqn{\lambda_k} (\code{"cont_haz"}):
+\itemize{
+\item Trapezoidal rule:
+\deqn{S_j = \exp\!\left(-\sum_{k=1}^j \frac{\lambda_{k-1} + \lambda_k}{2} \Delta_k\right)}
+(with \eqn{\lambda_0 = \lambda_1})
+\item Left Riemann sum:
 \deqn{S_j = \exp\!\left(-\sum_{k=1}^j \lambda_k \Delta_k\right)}
 }
+}
+
+For continuous inputs (\code{"cont_dens"} / \code{"cont_haz"}), numerical integration
+can be done either with the trapezoidal rule (\code{integration = "trapezoid"}, default)
+or with a left Riemann sum (\code{integration = "riemann"}).
+Trapezoidal rule is more accurate (lower approximation error in the order of \eqn{\Delta^2}
+while the Riemann sum has an approximation error in the order of \eqn{\Delta}).
+At the first anchor both rules are identical, because no previous anchor value
+is available; therefore both use \eqn{x_1 \Delta_1}.
 }
 \section{Validation}{
 

--- a/man/interp.Rd
+++ b/man/interp.Rd
@@ -71,7 +71,8 @@ piecewise constant interpolation of the density function).
 piecewise constant interpolation of the hazard function).
 }
 
-For formulas for each method, see respective Tables in arxiv preprint (TODO: add link).
+We will provide tables with the interpolation formulas for each method in an
+upcoming arXiv preprint and link it here.
 
 For constant hazard interpolation (\code{"const_haz"}), any right-anchor S(t) values
 equal to 0 are internally floored at \code{min(1e-12, S_left)} within each interval.

--- a/man/interp.Rd
+++ b/man/interp.Rd
@@ -13,7 +13,7 @@ interp(
   add_times = TRUE,
   check = TRUE,
   eps = 1e-12,
-  trim_duplicates = FALSE
+  trim_dups = FALSE
 )
 }
 \arguments{
@@ -46,7 +46,7 @@ set to \code{FALSE} to skip checks (NOT recommended for external use).}
 Small positive value used to replace extremely low survival probabilities when computing cumulative hazard,
 preventing numerical instability in \eqn{-\log S(t)} calculations.}
 
-\item{trim_duplicates}{(\code{logical(1)})\cr
+\item{trim_dups}{(\code{logical(1)})\cr
 If \code{TRUE}, removes adjacent duplicate values from the input using \code{\link[=trim_duplicates]{trim_duplicates()}}.
 This eliminates flat segments in survival curves and improves interpolation efficiency.
 Default is \code{FALSE}.}

--- a/man/survDistr.Rd
+++ b/man/survDistr.Rd
@@ -112,7 +112,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
 A numeric matrix of survival probabilities (values between 0 and 1).
 Column names must correspond to time points if \code{times} is \code{NULL}.}
 
-\item{\code{times}}{(\code{numeric(1)})\cr Numeric vector of time points for matrix \code{x},
+\item{\code{times}}{(\code{numeric()})\cr Numeric vector of time points for matrix \code{x},
 must match the number of columns.}
 
 \item{\code{method}}{(\code{character(1)})\cr

--- a/man/survDistr.Rd
+++ b/man/survDistr.Rd
@@ -24,7 +24,7 @@ interpolated using the \code{\link[=interp]{interp()}} function.
 \code{check} is set to \code{TRUE}.
 \item Use the \verb{$filter()} method to subset observations in-place by filtering rows of the
 stored matrix.
-\item Use \code{trim_duplicates = TRUE} in the constructor to remove flat survival segments (repeated
+\item Use \code{trim_dups = TRUE} in the constructor to remove flat survival segments (repeated
 values across time points) with a pre-specified tolerance (for a more controlled
 pre-processing, see \code{\link[=trim_duplicates]{trim_duplicates()}}).
 }
@@ -101,7 +101,7 @@ Creates a new instance of this \link[R6:R6Class]{R6} class.
   times = NULL,
   method = "const_surv",
   check = TRUE,
-  trim_duplicates = FALSE
+  trim_dups = FALSE
 )}\if{html}{\out{</div>}}
 }
 
@@ -123,7 +123,7 @@ and \code{"const_haz"} (alias: \code{"exp_surv"}).}
 If \code{TRUE}, run input matrix validation checks using \code{\link[=assert_prob]{assert_prob()}};
 set to \code{FALSE} to skip checks (NOT recommended for external use).}
 
-\item{\code{trim_duplicates}}{(\code{logical(1)})\cr
+\item{\code{trim_dups}}{(\code{logical(1)})\cr
 If \code{TRUE}, removes adjacent duplicate values from the input using \code{\link[=trim_duplicates]{trim_duplicates()}}.
 This eliminates flat segments in survival curves and improves interpolation efficiency.
 Default is \code{FALSE}.}

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -113,26 +113,28 @@ BEGIN_RCPP
 END_RCPP
 }
 // c_cont_dens_to_surv_mat
-NumericMatrix c_cont_dens_to_surv_mat(const NumericMatrix& x, const NumericVector& times);
-RcppExport SEXP _survdistr_c_cont_dens_to_surv_mat(SEXP xSEXP, SEXP timesSEXP) {
+NumericMatrix c_cont_dens_to_surv_mat(const NumericMatrix& x, const NumericVector& times, const bool trapezoid);
+RcppExport SEXP _survdistr_c_cont_dens_to_surv_mat(SEXP xSEXP, SEXP timesSEXP, SEXP trapezoidSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const NumericMatrix& >::type x(xSEXP);
     Rcpp::traits::input_parameter< const NumericVector& >::type times(timesSEXP);
-    rcpp_result_gen = Rcpp::wrap(c_cont_dens_to_surv_mat(x, times));
+    Rcpp::traits::input_parameter< const bool >::type trapezoid(trapezoidSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_cont_dens_to_surv_mat(x, times, trapezoid));
     return rcpp_result_gen;
 END_RCPP
 }
 // c_cont_haz_to_surv_mat
-NumericMatrix c_cont_haz_to_surv_mat(const NumericMatrix& x, const NumericVector& times);
-RcppExport SEXP _survdistr_c_cont_haz_to_surv_mat(SEXP xSEXP, SEXP timesSEXP) {
+NumericMatrix c_cont_haz_to_surv_mat(const NumericMatrix& x, const NumericVector& times, const bool trapezoid);
+RcppExport SEXP _survdistr_c_cont_haz_to_surv_mat(SEXP xSEXP, SEXP timesSEXP, SEXP trapezoidSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< const NumericMatrix& >::type x(xSEXP);
     Rcpp::traits::input_parameter< const NumericVector& >::type times(timesSEXP);
-    rcpp_result_gen = Rcpp::wrap(c_cont_haz_to_surv_mat(x, times));
+    Rcpp::traits::input_parameter< const bool >::type trapezoid(trapezoidSEXP);
+    rcpp_result_gen = Rcpp::wrap(c_cont_haz_to_surv_mat(x, times, trapezoid));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -146,8 +148,8 @@ static const R_CallMethodDef CallEntries[] = {
     {"_survdistr_c_interp_surv_mat", (DL_FUNC) &_survdistr_c_interp_surv_mat, 4},
     {"_survdistr_c_disc_dens_to_surv_mat", (DL_FUNC) &_survdistr_c_disc_dens_to_surv_mat, 1},
     {"_survdistr_c_disc_haz_to_surv_mat", (DL_FUNC) &_survdistr_c_disc_haz_to_surv_mat, 1},
-    {"_survdistr_c_cont_dens_to_surv_mat", (DL_FUNC) &_survdistr_c_cont_dens_to_surv_mat, 2},
-    {"_survdistr_c_cont_haz_to_surv_mat", (DL_FUNC) &_survdistr_c_cont_haz_to_surv_mat, 2},
+    {"_survdistr_c_cont_dens_to_surv_mat", (DL_FUNC) &_survdistr_c_cont_dens_to_surv_mat, 3},
+    {"_survdistr_c_cont_haz_to_surv_mat", (DL_FUNC) &_survdistr_c_cont_haz_to_surv_mat, 3},
     {NULL, NULL, 0}
 };
 

--- a/src/interp_surv.cpp
+++ b/src/interp_surv.cpp
@@ -126,7 +126,7 @@ NumericMatrix c_interp_surv_mat(
         double val = S_left + alpha * (S_right - S_left);
         survival(i, k) = std::max(0.0, std::min(1.0, val));
       } else { // CONST_HAZ
-        // avoid unnessary division by zero
+        // avoid unnecessary division by zero
         if (S_left == 0.0) {
           survival(i, k) = 0.0;
         } else {

--- a/src/trafo.cpp
+++ b/src/trafo.cpp
@@ -43,7 +43,8 @@ NumericMatrix c_disc_haz_to_surv_mat(const NumericMatrix& x) {
 // [[Rcpp::export]]
 NumericMatrix c_cont_dens_to_surv_mat(
   const NumericMatrix& x,
-  const NumericVector& times
+  const NumericVector& times,
+  const bool trapezoid = true
 ) {
   const int n_rows = x.nrow();
   const int n_times = x.ncol();
@@ -56,10 +57,19 @@ NumericMatrix c_cont_dens_to_surv_mat(
   }
 
   for (int i = 0; i < n_rows; i++) {
-    double cum_int = 0.0;
-    for (int j = 0; j < n_times; j++) {
-      cum_int += x(i, j) * delta_t[j];
-      surv(i, j) = 1.0 - cum_int;
+    double cdf = 0.0;
+
+    // For the first anchor there is no previous anchor value available,
+    // so both integration rules use the same formula:
+    cdf += x(i, 0) * delta_t[0];
+    surv(i, 0) = 1.0 - cdf;
+    for (int j = 1; j < n_times; j++) {
+      if (trapezoid) {
+        cdf += 0.5 * (x(i, j - 1) + x(i, j)) * delta_t[j];
+      } else {
+        cdf += x(i, j) * delta_t[j];
+      }
+      surv(i, j) = 1.0 - cdf;
     }
   }
 
@@ -70,7 +80,8 @@ NumericMatrix c_cont_dens_to_surv_mat(
 // [[Rcpp::export]]
 NumericMatrix c_cont_haz_to_surv_mat(
   const NumericMatrix& x,
-  const NumericVector& times
+  const NumericVector& times,
+  const bool trapezoid = true
 ) {
   const int n_rows = x.nrow();
   const int n_times = x.ncol();
@@ -84,8 +95,17 @@ NumericMatrix c_cont_haz_to_surv_mat(
 
   for (int i = 0; i < n_rows; i++) {
     double cum_haz = 0.0;
-    for (int j = 0; j < n_times; j++) {
-      cum_haz += x(i, j) * delta_t[j];
+
+    // For the first anchor there is no previous anchor value available,
+    // so both integration rules use the same formula:
+    cum_haz += x(i, 0) * delta_t[0];
+    surv(i, 0) = std::exp(-cum_haz);
+    for (int j = 1; j < n_times; j++) {
+      if (trapezoid) {
+        cum_haz += 0.5 * (x(i, j - 1) + x(i, j)) * delta_t[j];
+      } else {
+        cum_haz += x(i, j) * delta_t[j];
+      }
       surv(i, j) = std::exp(-cum_haz);
     }
   }

--- a/tests/testthat/test_convert_to_surv.R
+++ b/tests/testthat/test_convert_to_surv.R
@@ -5,28 +5,60 @@ test_that("convert_to_surv() works", {
   disc_dens = c(0.1, 0.2, 0.15)
   expect_equal(
     convert_to_surv(disc_dens, times = times, input = "disc_dens"),
-    c(0.9, 0.7, 0.55)
+    c(
+      1 - 0.1,
+      1 - 0.1 - 0.2,
+      1 - 0.1 - 0.2 - 0.15
+    )
   )
 
   # continuous density (Delta = 1, 2, 3)
   cont_dens = c(0.1, 0.05, 0.1)
   expect_equal(
-    convert_to_surv(cont_dens, times = times, input = "cont_dens"),
-    c(0.9, 0.8, 0.5)
+    convert_to_surv(cont_dens, times = times, input = "cont_dens", integration = "riemann"),
+    c(
+      1 - (0.1 * 1),
+      1 - (0.1 * 1 + 0.05 * 2),
+      1 - (0.1 * 1 + 0.05 * 2 + 0.1 * 3)
+    )
+  )
+  expect_equal(
+    convert_to_surv(cont_dens, times = times, input = "cont_dens", integration = "trapezoid"),
+    c(
+      1 - (0.1 * 1),
+      1 - (0.1 * 1 + 0.5 * (0.1 + 0.05) * 2),
+      1 - (0.1 * 1 + 0.5 * (0.1 + 0.05) * 2 + 0.5 * (0.05 + 0.1) * 3)
+    )
   )
 
   # discrete hazard
   disc_haz = c(0.1, 0.2, 0.5)
   expect_equal(
     convert_to_surv(disc_haz, times = times, input = "disc_haz"),
-    c(0.9, 0.72, 0.36)
+    c(
+      1 - 0.1,
+      (1 - 0.1) * (1 - 0.2),
+      (1 - 0.1) * (1 - 0.2) * (1 - 0.5)
+    )
   )
 
   # continuous hazard (delta = 1, 2, 3)
   cont_haz = c(0.1, 0.05, 0.2)
   expect_equal(
-    convert_to_surv(cont_haz, times = times, input = "cont_haz"),
-    exp(-c(0.1, 0.2, 0.8))
+    convert_to_surv(cont_haz, times = times, input = "cont_haz", integration = "riemann"),
+    exp(-c(
+      0.1 * 1,
+      0.1 * 1 + 0.05 * 2,
+      0.1 * 1 + 0.05 * 2 + 0.2 * 3
+    ))
+  )
+  expect_equal(
+    convert_to_surv(cont_haz, times = times, input = "cont_haz", integration = "trapezoid"),
+    exp(-c(
+      0.1 * 1,
+      0.1 + (0.5 * (0.1 + 0.05) * 2),
+      0.1 + (0.5 * (0.1 + 0.05) * 2) + (0.5 * (0.05 + 0.2) * 3)
+    ))
   )
 
   # matrix input works

--- a/tests/testthat/test_interp_cif.R
+++ b/tests/testthat/test_interp_cif.R
@@ -45,7 +45,6 @@ test_that("interp_cif handles single time point", {
   expect_equal(res, expected, ignore_attr = TRUE)
 })
 
-
 test_that("interp_cif returns original matrix when eval_times is NULL", {
   cif = gen_random_mat(3, 4, type = "cif")
   times = c(1, 3, 5, 7)

--- a/tests/testthat/test_interp_surv.R
+++ b/tests/testthat/test_interp_surv.R
@@ -33,19 +33,19 @@ test_that("interp() can trim duplicate S(t) values", {
   x = c(1, 1, 1, 0.6, 0, 0)
   t = c(0, 1, 2, 3,   4, 5)
   expect_lt(
-    interp(x, t, eval_times = 1.5, method = "linear_surv", add_times = FALSE, trim_duplicates = TRUE),
+    interp(x, t, eval_times = 1.5, method = "linear_surv", add_times = FALSE, trim_dups = TRUE),
     1L
   )
   expect_lt(
-    interp(x, t, eval_times = 1.5, method = "exp_surv", add_times = FALSE, trim_duplicates = TRUE),
+    interp(x, t, eval_times = 1.5, method = "exp_surv", add_times = FALSE, trim_dups = TRUE),
     1L
   )
   expect_gt(
-    interp(x, t, eval_times = 3.5, method = "linear_surv", add_times = FALSE, trim_duplicates = TRUE),
+    interp(x, t, eval_times = 3.5, method = "linear_surv", add_times = FALSE, trim_dups = TRUE),
     0L
   )
   expect_equal(
-    interp(x, t, eval_times = 4.5, method = "exp_surv", add_times = FALSE, trim_duplicates = TRUE),
+    interp(x, t, eval_times = 4.5, method = "exp_surv", add_times = FALSE, trim_dups = TRUE),
     0L
   )
 })

--- a/tests/testthat/test_survDistr.R
+++ b/tests/testthat/test_survDistr.R
@@ -23,10 +23,10 @@ test_that("new() works", {
   expect_error(survDistr$new(x = matrix()), "Contains missing values")
   expect_error(survDistr$new(x = matrix(dimnames = list(NULL, 1))), "Contains missing values")
 
-  # trim_duplicates works and removes flat segments
+  # trim_dups works and removes flat segments
   mat = matrix(c(1, 1, 0.8, 0.7, 0.7, 0.5), nrow = 2, byrow = TRUE)
   times = 1:3
-  obj2 = survDistr$new(mat, times, trim_duplicates = TRUE)
+  obj2 = survDistr$new(mat, times, trim_dups = TRUE)
   expect_equal(dim(obj2$data(add_times = FALSE)), c(2, 2))
   expect_equal(obj2$times, c(1, 3))
 })


### PR DESCRIPTION
## Summary

Fixes several documentation issues identified during a code review:

- **Badge link**: `r-cmd-check` badge pointed to `mlr3survival` repo instead of `survdistr`
- **Type annotation**: `@param times` in `survDistr$new()` was typed as `numeric(1)` (scalar) but is a vector — corrected to `numeric()`
- **Whitespace**: removed leading whitespace from `man-roxygen/param_rows.R` and trailing whitespace/blank line from `man-roxygen/param_method.R`
- **NEWS.md grammar**: "Unified assertion function to one" → "Unified assertion functions into one"
- **Typo**: "unnessary" → "unnecessary" in `interp_surv.cpp`

## Issues deferred (as comments/follow-ups)

The following items from the review are not included here and should be addressed separately:

1. **Unresolved TODO** (`interp.R:18`): `"For formulas for each method, see ... arxiv preprint (TODO: add link)."` — add link once available or remove sentence.
2. **`convert_to_surv` with `times[0] = 0`** (`trafo.cpp:53`): when `input = "cont_haz"` or `"cont_dens"` and `times[0] = 0`, the first value silently contributes nothing (`delta_t[0] = 0`). The docs example shows this exact case. Add a `@note` or a warning.
3. **`assert_prob` description** (`assertions.R:60`): condition #1 says "input `x` is a numeric matrix" but vectors are also accepted. Clarify.
4. **`interp_cif()` method not documented** (`interp.R:129`): only does `const_surv` but no `method` param or explanation why. Add a `@details` note.
5. **`eps` inconsistency in `survDistr`** (`survDistr.R:212`): `cumhazard()` exposes `eps`; `hazard()` and `density()` do not — consider aligning.
6. **`data()` params** (`survDistr.R:132`): `add_times` is not documented in the roxygen for `data()`.
7. **`trim_duplicates` name collision** (`interp.R:92`): parameter `trim_duplicates` has the same name as the function called in the body. Works correctly in R (scalars don't shadow function lookup), but consider renaming the parameter to `trim_dups` for clarity.